### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Insert this little snippet into your css file and everything should work fine.
 
 At this moment Loadie.js (v1.0) doesn't support extensive options. If you have any ideas what Loadie.js could be, just leave us an issue at Github.
 
-##Copyright
+## Copyright
 
 This nice little jQuery plugin was crafted by [@iDuuck](http://twitter.com/iDuuck) of [9elements](http://9elements.com).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
